### PR TITLE
(maint) fix flaky test and stop lying about :create

### DIFF
--- a/apps/web/lib/web/controllers/github_webhook_controller.ex
+++ b/apps/web/lib/web/controllers/github_webhook_controller.ex
@@ -5,12 +5,11 @@ defmodule Web.GitHubWebhookController do
   use Web, :controller
 
   alias Data.{Opportunities, Projects}
-  alias Web.TaskSupervisor
 
   def create(conn, %{"action" => action, "issue" => issue} = issue_event)
     when is_map(issue) and action in ["closed", "labeled", "opened", "reopened"] do
 
-    Task.Supervisor.start_child(TaskSupervisor, __MODULE__, :process_issue, [issue_event])
+    process_issue(issue_event)
 
     thank_you(conn)
   end

--- a/apps/web/test/web/controllers/github_webhook_controller_test.exs
+++ b/apps/web/test/web/controllers/github_webhook_controller_test.exs
@@ -40,8 +40,6 @@ defmodule Web.GitHubWebhookControllerTest do
 
     json_response(conn, 201)
 
-    Process.sleep(10)
-
     opportunities = Opportunities.all()
     assert length(opportunities) == 1
   end


### PR DESCRIPTION
Prior to this commit the initial test of `GithubWebhookController.create`
was flaky for two related reasons:
 1. the controller was spawning an additional process (aside from the
one handling the webhook request) to store the Opportunity into the
database, 
2. the test for `create` was testing two distinct things:
   * `201 Created` response from webhook endpoint (potentially a lie,
   * more on that later) an Opportunity was inserted into the database.

Because the controller was spawning an additional process and the test
was checking the side effects of that process, we had a race condition
on our hands. The first hint of the race condition was the
`Process.sleep` in the test. One could certainly extend the sleep time
in the test to avoid the race condition most of the time, merely
delaying the problem and sacrificing test speed, but the more correct
solution is in the implicit answer we give when processing the webhook
payload. Before this commit we were stating that we had definitely, 100%
created the Opportunity in the database, which, as indicated by the
`Process.sleep` was a lie. We *intended* to insert the Opportunity into
the database, but we might not be able to (for a variety of reasons).

This leaves us with two architectural front-runners:
 * a CQRS model, where we *explicitly* state "we _intend_ to write this,
   but we aren't sure if we actually _can_, check back with us later
   using this token"
 * a synchronous write model

Because GitHub doesn't care about what we do with the payload and
whether or not we actually succeed, the CQRS model is a slight misfit.
The synchronous write model, however, provides us with the advantages of
not stating `201 Created` until it's actually in the DB, and if the DB
write *does* fail, our request-process will die with a 500, which *is* a
trigger for GitHub (and Bitbucket) to reattempt payload delivery later,
giving us another chance at inserting it.  Additionally, if/when we have
monitoring, those 500s will be easily surfaced.

Therefore, this commit opts for a synchronous database write during
webhook payload processing and removes the troublesome `Process.sleep`
from the test.

---
In reference to discussion on #25 between @doomspork and @ybur-yug 

Also, I gather that GIFs or videos are required, so [here you go](https://www.youtube.com/watch?v=3tigVYfHVmQ)
![screenshot_20170824_012917](https://user-images.githubusercontent.com/818053/29657195-bae9f89e-886b-11e7-8918-b8d534f31c92.png)
