### PR TITLE
Internationalize Opportunity levels

### DIFF
--- a/apps/data/config/config.exs
+++ b/apps/data/config/config.exs
@@ -2,7 +2,7 @@ use Mix.Config
 
 config :data,
   ecto_repos: [Data.Repo],
-  levels: ["beginner", "intermediate", "advanced"]
+  levels: [1, 5, 9]
 
 config :data, Data.Repo,
   loggers: [Appsignal.Ecto, Ecto.LogEntry]

--- a/apps/data/lib/data/schemas/opportunity.ex
+++ b/apps/data/lib/data/schemas/opportunity.ex
@@ -12,7 +12,7 @@ defmodule Data.Opportunity do
 
   schema "opportunities" do
     field :closed_at, :utc_datetime # when it was closed/completed
-    field :level, :string # starter, intermediate, advanced
+    field :level, :integer # placeholder for starter, intermediate, advanced
     field :title, :string
     field :url, :string
 

--- a/apps/data/priv/repo/migrations/20170829042355_convert_opportunity_level_to_integer.exs
+++ b/apps/data/priv/repo/migrations/20170829042355_convert_opportunity_level_to_integer.exs
@@ -1,0 +1,8 @@
+defmodule Data.Repo.Migrations.ConvertOpportunityLevelToInteger do
+  use Ecto.Migration
+
+  def change do
+    execute "UPDATE opportunities set level = case when level = 'starter' then '1' when level = 'beginner' then '1' when level = 'intermediate' then '5' when level = 'advanced' then '9' else '-1' end;"
+    execute "ALTER TABLE opportunities ALTER COLUMN level TYPE integer USING (level::integer);"
+  end
+end

--- a/apps/data/test/lib/opportunities_test.exs
+++ b/apps/data/test/lib/opportunities_test.exs
@@ -7,7 +7,7 @@ defmodule Data.OpportunitiesTest do
 
   test "inserts new opportunity when valid" do
     attributes = %{
-      level: "beginner",
+      level: 1,
       project_id: insert(:project).id,
       title: "Example Opportunity",
       url: "https://example.com/tracker/1"
@@ -25,7 +25,7 @@ defmodule Data.OpportunitiesTest do
     insert(:opportunity, title: "B Example")
     insert(:opportunity, title: "C Example")
     insert(:opportunity, title: "A Example")
-    %{entries: opportunities} = Opportunities.all(%{sort_by: :title}) 
+    %{entries: opportunities} = Opportunities.all(%{sort_by: :title})
 
     assert [%{title: "A Example"}, %{title: "B Example"}, %{title: "C Example"}] = opportunities
   end

--- a/apps/data/test/lib/schemas/opportunity_test.exs
+++ b/apps/data/test/lib/schemas/opportunity_test.exs
@@ -25,7 +25,7 @@ defmodule Data.OpportunityTest do
 
   test "opportunity is valid" do
     attributes = %{
-      level: "beginner",
+      level: 1,
       project_id: insert(:project).id,
       title: "Example Opportunity",
       url: "https://example.com/tracker/1"

--- a/apps/data/test/support/factory.ex
+++ b/apps/data/test/support/factory.ex
@@ -13,7 +13,7 @@ defmodule Data.Factory do
 
   def opportunity_factory do
     %Opportunity{
-      level: "starter",
+      level: 1,
       title: "Example Opportunity",
       url: sequence("https://example.com/tracker/"),
       project: build(:project)

--- a/apps/web/assets/css/app.scss
+++ b/apps/web/assets/css/app.scss
@@ -18,9 +18,9 @@
 
 $small-font-size: 0.75em;
 $badges: (
-  "starter": #e6efc2,
-  "advanced": #fbe3e4,
-  "intermediate": #fff6bf,
+  "1": #e6efc2,
+  "9": #fbe3e4,
+  "5": #fff6bf,
   "tag": #eee,
 ) !default;
 html,

--- a/apps/web/config/config.exs
+++ b/apps/web/config/config.exs
@@ -9,9 +9,9 @@ use Mix.Config
 config :web,
   namespace: Web,
   level_label_mapping: %{
-    "beginner" => ["Kind:Beginner", "Kind:Starter", "level:starter"],
-    "intermediate" => ["Kind:Intermediate", "level:intermediate"],
-    "advanced" => ["Kind:Advanced", "level:advanced"]
+    1 => ["Kind:Beginner", "Kind:Starter", "level:starter"],
+    5 => ["Kind:Intermediate", "level:intermediate"],
+    9 => ["Kind:Advanced", "level:advanced"]
   }
 
 # Configures the endpoint

--- a/apps/web/lib/web/controllers/locale.ex
+++ b/apps/web/lib/web/controllers/locale.ex
@@ -1,0 +1,19 @@
+defmodule Web.Locale do
+  @moduledoc """
+  Plug to pull the locale from either a parameter or the session and
+  pass it on to Gettext for serving up the appropriate translations
+  """
+
+  import Plug.Conn
+
+  def init(_opts), do: nil
+
+  def call(conn, _opts) do
+    case conn.params["locale"] || get_session(conn, :locale) do
+      nil -> conn
+      locale ->
+        Gettext.put_locale(Web.Gettext, locale)
+        conn |> put_session(:locale, locale)
+    end
+  end
+end

--- a/apps/web/lib/web/router.ex
+++ b/apps/web/lib/web/router.ex
@@ -11,6 +11,7 @@ defmodule Web.Router do
     plug :fetch_flash
     plug :protect_from_forgery
     plug :put_secure_browser_headers
+    plug Web.Locale
   end
 
   scope "/", Web do

--- a/apps/web/lib/web/templates/opportunities/opportunities.html.eex
+++ b/apps/web/lib/web/templates/opportunities/opportunities.html.eex
@@ -19,7 +19,7 @@
         <%= for tag <- results.project.tags do %>
         <span class="badge-tag"><svg class="icon icon-tag"><use xlink:href="#icon-tag"></use></svg> <%= tag %></span>
         <% end %>
-          <span class="badge-<%= results.level %>"><%= results.level %></span></div>
+        <span class="badge-<%= results.level %>"><%= translated_difficulty(results) %></span></div>
       </div>
     </div>
   <% end %>

--- a/apps/web/lib/web/views/opportunities_view.ex
+++ b/apps/web/lib/web/views/opportunities_view.ex
@@ -1,3 +1,16 @@
 defmodule Web.OpportunitiesView do
   use Web, :view
+
+  # rather than dynamically creating the gettext key, this function
+  # has static gettext keys so that the `mix gettext.extract` can
+  # properly locate them and pull them out into the translation
+  # files
+  def translated_difficulty(opportunity) do
+    case opportunity.level do
+      1 -> gettext("difficulty-starter")
+      5 -> gettext("difficulty-intermediate")
+      9 -> gettext("difficulty-advanced")
+      _ -> gettext("difficulty-unknown")
+    end
+  end
 end

--- a/apps/web/priv/gettext/de/LC_MESSAGES/default.po
+++ b/apps/web/priv/gettext/de/LC_MESSAGES/default.po
@@ -1,0 +1,27 @@
+## `msgid`s in this file come from POT (.pot) files.
+##
+## Do not add, change, or remove `msgid`s manually here as
+## they're tied to the ones in the corresponding POT file
+## (with the same domain).
+##
+## Use `mix gettext.extract --merge` or `mix gettext.merge`
+## to merge POT files into PO files.
+msgid ""
+msgstr ""
+"Language: de\n"
+
+#: lib/web/views/opportunities_view.ex:8
+msgid "difficulty-advanced"
+msgstr "Schwierig"
+
+#: lib/web/views/opportunities_view.ex:7
+msgid "difficulty-intermediate"
+msgstr "Mittel"
+
+#: lib/web/views/opportunities_view.ex:6
+msgid "difficulty-starter"
+msgstr "Leicht"
+
+#: lib/web/views/opportunities_view.ex:9
+msgid "difficulty-unknown"
+msgstr "Unbekannt"

--- a/apps/web/priv/gettext/de/LC_MESSAGES/errors.po
+++ b/apps/web/priv/gettext/de/LC_MESSAGES/errors.po
@@ -1,52 +1,45 @@
-## This file is a PO Template file.
+## `msgid`s in this file come from POT (.pot) files.
 ##
-## `msgid`s here are often extracted from source code.
-## Add new translations manually only if they're dynamic
-## translations that can't be statically extracted.
+## Do not add, change, or remove `msgid`s manually here as
+## they're tied to the ones in the corresponding POT file
+## (with the same domain).
 ##
-## Run `mix gettext.extract` to bring this file up to
-## date. Leave `msgstr`s empty as changing them here as no
-## effect: edit them in PO (`.po`) files instead.
-## From Ecto.Changeset.cast/4
+## Use `mix gettext.extract --merge` or `mix gettext.merge`
+## to merge POT files into PO files.
+msgid ""
+msgstr ""
+"Language: de\n"
+
 msgid "can't be blank"
 msgstr ""
 
-## From Ecto.Changeset.unique_constraint/3
 msgid "has already been taken"
 msgstr ""
 
-## From Ecto.Changeset.put_change/3
 msgid "is invalid"
 msgstr ""
 
-## From Ecto.Changeset.validate_acceptance/3
 msgid "must be accepted"
 msgstr ""
 
-## From Ecto.Changeset.validate_format/3
 msgid "has invalid format"
 msgstr ""
 
-## From Ecto.Changeset.validate_subset/3
 msgid "has an invalid entry"
 msgstr ""
 
-## From Ecto.Changeset.validate_exclusion/3
 msgid "is reserved"
 msgstr ""
 
-## From Ecto.Changeset.validate_confirmation/3
 msgid "does not match confirmation"
 msgstr ""
 
-## From Ecto.Changeset.no_assoc_constraint/3
 msgid "is still associated with this entry"
 msgstr ""
 
 msgid "are still associated with this entry"
 msgstr ""
 
-## From Ecto.Changeset.validate_length/3
 msgid "should be %{count} character(s)"
 msgid_plural "should be %{count} character(s)"
 msgstr[0] ""
@@ -77,7 +70,6 @@ msgid_plural "should have at most %{count} item(s)"
 msgstr[0] ""
 msgstr[1] ""
 
-## From Ecto.Changeset.validate_number/3
 msgid "must be less than %{number}"
 msgstr ""
 

--- a/apps/web/priv/gettext/default.pot
+++ b/apps/web/priv/gettext/default.pot
@@ -1,0 +1,27 @@
+## This file is a PO Template file.
+##
+## `msgid`s here are often extracted from source code.
+## Add new translations manually only if they're dynamic
+## translations that can't be statically extracted.
+##
+## Run `mix gettext.extract` to bring this file up to
+## date. Leave `msgstr`s empty as changing them here as no
+## effect: edit them in PO (`.po`) files instead.
+msgid ""
+msgstr ""
+
+#: lib/web/views/opportunities_view.ex:8
+msgid "difficulty-advanced"
+msgstr "Advanced"
+
+#: lib/web/views/opportunities_view.ex:7
+msgid "difficulty-intermediate"
+msgstr "Intermediate"
+
+#: lib/web/views/opportunities_view.ex:6
+msgid "difficulty-starter"
+msgstr "Starter"
+
+#: lib/web/views/opportunities_view.ex:9
+msgid "difficulty-unknown"
+msgstr "Unknown"

--- a/apps/web/priv/gettext/en/LC_MESSAGES/default.po
+++ b/apps/web/priv/gettext/en/LC_MESSAGES/default.po
@@ -1,0 +1,27 @@
+## `msgid`s in this file come from POT (.pot) files.
+##
+## Do not add, change, or remove `msgid`s manually here as
+## they're tied to the ones in the corresponding POT file
+## (with the same domain).
+##
+## Use `mix gettext.extract --merge` or `mix gettext.merge`
+## to merge POT files into PO files.
+msgid ""
+msgstr ""
+"Language: en\n"
+
+#: lib/web/views/opportunities_view.ex:8
+msgid "difficulty-advanced"
+msgstr "Advanced"
+
+#: lib/web/views/opportunities_view.ex:7
+msgid "difficulty-intermediate"
+msgstr "Intermediate"
+
+#: lib/web/views/opportunities_view.ex:6
+msgid "difficulty-starter"
+msgstr "Starter"
+
+#: lib/web/views/opportunities_view.ex:9
+msgid "difficulty-unknown"
+msgstr "Unknown"

--- a/apps/web/test/web/controllers/opportunities_controller_test.exs
+++ b/apps/web/test/web/controllers/opportunities_controller_test.exs
@@ -7,7 +7,7 @@ defmodule Web.OpportunitiesControllerTest do
     {:ok, %{id: project_id}} = Projects.insert(%{name: "Example Project", url: "example.com"})
 
     attributes = %{
-      level: "beginner",
+      level: 1,
       project_id: project_id,
       title: "Example Opportunity",
       url: "https://example.com/tracker/1"

--- a/apps/web/test/web/views/opportunities_view_test.exs
+++ b/apps/web/test/web/views/opportunities_view_test.exs
@@ -1,0 +1,22 @@
+defmodule Web.OpportunitiesViewTest do
+  use Web.ConnCase, async: true
+
+  alias Web.OpportunitiesView
+
+  test "defaults to English" do
+    assert String.match? OpportunitiesView.translated_difficulty(%{level: 1}), ~r/Starter/
+    assert String.match? OpportunitiesView.translated_difficulty(%{level: 5}), ~r/Intermediate/
+    assert String.match? OpportunitiesView.translated_difficulty(%{level: 9}), ~r/Advanced/
+  end
+
+  test "labels problematic values unknown" do
+    assert String.match? OpportunitiesView.translated_difficulty(%{level: -10}), ~r/Unknown/
+  end
+
+  test "german translations" do
+    Gettext.put_locale(Web.Gettext, "de")
+    assert String.match? OpportunitiesView.translated_difficulty(%{level: 1}), ~r/Leicht/
+    assert String.match? OpportunitiesView.translated_difficulty(%{level: -10}), ~r/Unbekannt/
+  end
+
+end


### PR DESCRIPTION
Prior to this commit Opportunities were storing their associated level
as an English string in the database. This made two immediate things
difficult:

 1. Sorting from easiest to hardest
 2. Migrating data when level names change (beginner => starter)

In addition we have no provisions for being able to internationalize the
application.

This commit decides to use an integer as its internal representation for
the opportunity difficulty level. The first thing necessary task is to
alter the Ecto schema and the database. Because an existing database
might have valid opportunities in the form of "starter", "intermediate",
"advanced", these are migrated to a stringified integer before the table
itself is modified, while explicitly casting from the stringified
integer to an actual integer. Next we modify the edges of our system to
properly modify a payload with "Level:Beginner" into a `1` and similarly
when displaying an opportunity of difficulty level 1 showing `Starter`
by default or `Leicht` if the process locale is German.

This should close #30.

---
We can sort by `level`; although, default web page still sorts by `inserted_at`.
![screenshot_20170828_224423](https://user-images.githubusercontent.com/818053/29806611-292284d4-8c45-11e7-998e-52f9f1ee5ba3.png)

---
Default English translation
![screenshot_20170828_224438](https://user-images.githubusercontent.com/818053/29806617-3025c73c-8c45-11e7-9c01-0852d64cf14e.png)
---
Explicit `locale` param forcing (terrible) German translation
![screenshot_20170828_225918](https://user-images.githubusercontent.com/818053/29806623-361e8ade-8c45-11e7-856c-0fcb42e58b20.png)
