### PR TITLE
Fix the opportunities filtering

### DIFF
--- a/apps/web/lib/web/controllers/opportunities_controller.ex
+++ b/apps/web/lib/web/controllers/opportunities_controller.ex
@@ -14,7 +14,7 @@ defmodule Web.OpportunitiesController do
 
   defp current_page(params), do: Map.get(params, "page", 1)
 
-  defp level(%{"level" => ""}), do: []
+  defp level(%{"level" => ""}), do: [1, 5, 9]
   defp level(params) do
     params
     |> Map.get("level", "1,5,9")

--- a/apps/web/lib/web/templates/opportunities/opportunities.html.eex
+++ b/apps/web/lib/web/templates/opportunities/opportunities.html.eex
@@ -14,7 +14,7 @@
   <div class="col-6">
     <div class="row">
       <div class="col-12">
-        <h6 class="text-muted">Selected Difficulities</h6>
+        <h6 class="text-muted">Selected Difficulties</h6>
       </div>
       <div class="col-12">
         <%= level_selectors(@conn) %>

--- a/apps/web/lib/web/views/opportunities_view.ex
+++ b/apps/web/lib/web/views/opportunities_view.ex
@@ -18,7 +18,7 @@ defmodule Web.OpportunitiesView do
   end
 
   @doc """
-  Generate the HTML for the toggable difficulty selection
+  Generate the HTML for the togglable difficulty selection
   """
   def level_selectors(conn) do
     current_selection = selected_levels(conn)
@@ -34,9 +34,9 @@ defmodule Web.OpportunitiesView do
   defp level_selector(level, current_selection) do
     [badge, level_params] =
       if level in current_selection do
-        [level_badge(level, true), current_selection -- [level]]
+        [level_badge(level, true), (if length(current_selection) == 1, do: current_selection, else: current_selection -- [level])]
       else
-        [level_badge(level, false), [level|current_selection]]
+        [level_badge(level, Enum.empty?(current_selection)), [level|current_selection]]
       end
 
     query_params = %{level: Enum.join(level_params, ",")}


### PR DESCRIPTION
When i ran the latest version locally and clicked on the pagination link of the index page, the opportunities list was empty because of incorrect handling of case when the `level` in query string is empty. 
So this PR proposes the following changes:
- [x] Fixed a couple of misprints.
- [x] All the levels should be shown if for some reason `level` in query string is empty.
- [x] If only one level option left selected, it can't be disabled.
