### PR TITLE
Fix Roboto font

### DIFF
--- a/apps/web/assets/css/app.scss
+++ b/apps/web/assets/css/app.scss
@@ -1,6 +1,3 @@
-@charset "utf-8";
-@import url('https://fonts.googleapis.com/css?family=Roboto+Slab:300|Roboto:300,500');
-
 $base-duration: 150ms;
 $base-timing: ease;
 
@@ -68,7 +65,7 @@ svg{
 .icon {
   width: 1em;
   height: 1em;
-}   
+}
 
 .filters {
   padding-bottom: 20px;

--- a/apps/web/lib/web/templates/layout/app.html.eex
+++ b/apps/web/lib/web/templates/layout/app.html.eex
@@ -8,6 +8,7 @@
     <meta name="author" content="">
 
     <title>Extracurricular</title>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Slab:300|Roboto:300,500">
     <link rel="stylesheet" href="<%= static_path(@conn, "/css/app.css") %>">
   </head>
   <body>


### PR DESCRIPTION
Although CSS imports are less of an anti-pattern as they used to be, they should still be used sparingly, so I moved the loading of Roboto into the layout. This will also prevent Brunch from gobbling up the import.