### PR TITLE
Invert filter logic

### DIFF
--- a/apps/web/assets/css/app.css
+++ b/apps/web/assets/css/app.css
@@ -61,6 +61,7 @@ a {
   font-size: 14px;
   line-height: 20px;
   padding: 2px 10px;
+  cursor: pointer;
 }
 
 .badge__icon {

--- a/apps/web/assets/js/components/Filters.jsx
+++ b/apps/web/assets/js/components/Filters.jsx
@@ -1,15 +1,14 @@
 import React from 'react';
 
-const toggleLevels = function(levels, level) {
+const updateLevels = (levels, level) => {
   if (levels.includes(level)) {
-    const index = levels.indexOf(level);
-    levels.splice(index, 1);
-  } else {
-    levels.push(level);
+    // If the selected level is already present, filter it out and return the new array
+    return levels.filter(v => v !== level);
   }
 
-  return levels;
-};
+  // Otherwise, concat the new level on to the old ones
+  return [...levels, level];
+}
 
 export default class Filters extends React.Component {
   constructor(props) {
@@ -35,18 +34,16 @@ export default class Filters extends React.Component {
     this.toggleLevel(9);
   }
 
-  toggleLevel = (level) => {
-    const levels = this.props.filters.levels;
+  toggleLevel(level) {
+    const filters = this.props.filters;
+    // Create a new filters object by merging the levels array into the rest of the filters
+    const newFilters = Object.assign(
+      {},
+      filters,
+      { levels: updateLevels(filters.levels, level) }
+    );
 
-    if (levels.includes(level)) {
-      const index = levels.indexOf(level);
-      levels.splice(index, 1);
-    } else {
-      levels.push(level);
-    }
-
-    this.props.filters.levels = levels;
-    this.props.updateFilters(this.props.filters);
+    this.props.updateFilters(newFilters);
   }
 
   render() {

--- a/apps/web/assets/js/components/Home.jsx
+++ b/apps/web/assets/js/components/Home.jsx
@@ -10,7 +10,7 @@ export default class Home extends React.Component {
 
     this.state = {
       filters: {
-        levels: [1, 5, 9],
+        levels: [],
       },
     };
   }


### PR DESCRIPTION
As discussed in https://github.com/elixirschool/extracurricular/pull/57#issuecomment-332672552, this PR makes it so that *no* filters will be selected by default (which means that all open issues are returned), and more importantly, makes it so that clicking on a specific level will include that level (rather than exclude).

There are a couple other changes worth mentioning:
- Add `cursor: pointer` to the `.badge` class so that mousing over a filter badge will indicate that the badge is clickable
- Changed `Selected Difficulty:` to `Filter By Difficulty:`. I'm not attached to this one at all, but it seemed like it might be worth the change since we're starting out with no filters selected.
- Reworked the way the `Filters` React component functions. It was originally doing a lot of mutation of the `props` object, which can be troublesome due to how to React's render model works. Instead, it now transforms the `filters` object immutably and pass the entire new object to `setState` in the `App` component.