### PR TITLE
Sync GitHub scheduler with the database

### DIFF
--- a/apps/bot/lib/bot/schedulers/github_issues.ex
+++ b/apps/bot/lib/bot/schedulers/github_issues.ex
@@ -12,6 +12,7 @@ defmodule Bot.Scheduler.GitHubIssues do
   @projects_per_check 5
   @two_hours 7_200 # seconds
   @thirty_seconds 30_000 # milliseconds
+  @twelve_hours @two_hours * 6_000 # milliseconds
 
   def check_repo(%{id: project_id, url: url}) do
      url
@@ -34,8 +35,19 @@ defmodule Bot.Scheduler.GitHubIssues do
     {:noreply, new_state}
   end
 
+  def handle_info(:project_database_sync, state) do
+    new_state =
+      state
+      |> Map.merge(state, init_state())
+
+    Process.send_after(self(), :project_database_sync, @twelve_hours)
+
+   {:noreply, new_state}
+  end
+
   def init(_opts) do
     Process.send_after(self(), :checks, @thirty_seconds)
+    Process.send_after(self(), :project_database_sync, @twelve_hours)
 
     {:ok, init_state()}
   end


### PR DESCRIPTION
Adds a handle_info method to sync the project(s) state with the
project(s) state fetched from the database every 12 hours

Closes #43