### PR TITLE
[DOCS] Remove extra `node` from asssets command on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ $ mix ecto.setup
 Install node packages and build brunch assets:
 
 ```bash
-$ cd apps/web/assets && npm install && node node node_modules/brunch/bin/brunch build && cd ../../../
+$ cd apps/web/assets && npm install && node node_modules/brunch/bin/brunch build && cd ../../../
 ```
 
 And the fun part, running the server!  If you haven't done so already, this will compile your frontend dependencies:


### PR DESCRIPTION
The command had an extra `node` in it, this PR removes it :)