### PR TITLE
Adjust opportunity icon style

### DIFF
--- a/apps/web/assets/css/app.css
+++ b/apps/web/assets/css/app.css
@@ -181,6 +181,7 @@ a {
 .opportunity__title-icon {
   font-size: 18px;
   vertical-align: middle;
+  padding: 0 0.5em;
 }
 
 .opportunity__project {


### PR DESCRIPTION
The opportunity icon is too close to the project and issue names.
![Example](https://user-images.githubusercontent.com/5345029/31284935-b024f84a-aac2-11e7-9972-f14c73f75a3b.png)
This PR adds a small padding for it.